### PR TITLE
Changed stat.cpu.load which results in a null load value to stat.cpu.…

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function stats(backends, done){
 
 					server.containers++
 					server.memoryused += stat.memory.usage
-					server.load += stat.cpu.load
+					server.load += stat.cpu.load_average
 					server.rx += stat.network.rx_bytes
 					server.tx += stat.network.tx_bytes
 


### PR DESCRIPTION
Just a minor fix to use the cpu.load_average property instead of cpu.load which does not seem to exist on the latest version of cadvisor
